### PR TITLE
XenforoResourceManagerAPI-Java v1.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.jonahd345</groupId>
     <artifactId>xenfororesourcemanagerapi</artifactId>
-    <version>1.0.1</version>
+    <version>1.1.1</version>
     <packaging>jar</packaging>
 
     <name>XenforoResourceManagerAPI-Java</name>

--- a/src/main/java/de/jonahd345/xenfororesourcemanagerapi/service/HttpClientService.java
+++ b/src/main/java/de/jonahd345/xenfororesourcemanagerapi/service/HttpClientService.java
@@ -21,7 +21,6 @@ public class HttpClientService {
      * @throws IOException if an I/O exception occurs
      */
     public RequestResponse makeGetRequest(String url) throws IOException {
-        int httpCode = 0;
         URL urlObject = new URL(url);
         HttpURLConnection connection = (HttpURLConnection) urlObject.openConnection();
         connection.setRequestMethod("GET");
@@ -41,7 +40,7 @@ public class HttpClientService {
                 while ((inputLine = in.readLine()) != null) {
                     response.append(inputLine);
                 }
-                return new RequestResponse(httpCode, response.toString());
+                return new RequestResponse(responseCode, response.toString());
             }
         } finally {
             connection.disconnect();


### PR DESCRIPTION
- fix: correct variable name for HTTP response code in makeGetRequest method (every request "failed")